### PR TITLE
Add support for older ssh versions with no -J option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/squarescale/cloudresolver v0.0.0-20190824051432-de3eece6ac93
 	github.com/squarescale/sshcommand v0.0.0-20190311110043-d5b1f8b62c87
 	github.com/stretchr/testify v1.3.0 // indirect
+	go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b // indirect
 	golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9 // indirect


### PR DESCRIPTION
On Ubuntu 16.04 for instance ssh version is OpenSSH_7.2p2 and
does not support -J option