### PR TITLE
Improve host matching method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,7 @@ require (
 	github.com/spf13/viper v1.3.1
 	github.com/squarescale/cloudresolver v0.0.0-20190308221611-b60c2a377607
 	github.com/squarescale/sshcommand v0.0.0-20190311110043-d5b1f8b62c87
-	github.com/stretchr/testify v1.3.0 // indirect
-	go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2
 	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9 // indirect

--- a/pkg/libhssh/filter.go
+++ b/pkg/libhssh/filter.go
@@ -1,0 +1,82 @@
+package libhssh
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	cr "github.com/squarescale/cloudresolver"
+)
+
+var (
+	hostAttributes = map[string]string{}
+)
+
+func init() {
+	hostAttributes = initHostAttributes()
+}
+
+// ---
+
+type Filter struct {
+	fieldName       string
+	structFieldName string
+	pattern         *regexp.Regexp
+}
+
+func NewFilterFromString(s string) (*Filter, error) {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid filter format %q", s)
+	}
+
+	n := strings.ToLower(parts[0])
+
+	if !validFieldName(n) {
+		return nil, fmt.Errorf("Invalid field name %q", n)
+	}
+
+	reg, err := regexp.Compile(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Filter{
+		fieldName:       n,
+		structFieldName: hostAttributes[n],
+		pattern:         reg,
+	}, nil
+}
+
+func (f *Filter) HostMatch(h *cr.Host) bool {
+	val := reflect.ValueOf(h).Elem()
+
+	s, ok := val.FieldByName(f.structFieldName).Interface().(string)
+	if !ok {
+		return false
+	}
+
+	return f.pattern.MatchString(s)
+}
+
+// ---
+
+func initHostAttributes() map[string]string {
+	val := reflect.ValueOf(new(cr.Host)).Elem()
+
+	buff := map[string]string{}
+
+	for i := 0; i < val.NumField(); i++ {
+		v := val.Type().Field(i).Name
+		k := strings.ToLower(v)
+		buff[k] = v
+	}
+
+	return buff
+}
+
+func validFieldName(n string) bool {
+	_, found := hostAttributes[n]
+	return found
+}

--- a/pkg/libhssh/filter_test.go
+++ b/pkg/libhssh/filter_test.go
@@ -13,12 +13,6 @@ type FilterTestSuite struct {
 	suite.Suite
 }
 
-func (s *FilterTestSuite) SetupSuite() {
-}
-
-func (s *FilterTestSuite) SetupTest() {
-}
-
 func (s *FilterTestSuite) TestNewFilterFromString() {
 	reg, err := regexp.Compile("foo")
 	s.Nil(err)
@@ -42,25 +36,29 @@ func (s *FilterTestSuite) TestNewFilterFromString() {
 			expectedFilter: nil,
 		},
 		{
-			desc:           "Invalid field name && valid regexp",
+			desc:           "Unmatchable field name && valid value regexp",
 			filter:         "xxx:valid",
 			expectError:    true,
 			expectedFilter: nil,
 		},
 		{
-			desc:           "Valid field name && invalid regexp",
+			desc:           "Matchable field name && valid value regexp",
 			filter:         "id:[syntax error)",
 			expectError:    true,
 			expectedFilter: nil,
 		},
 		{
 			desc:        "Valid field name && valid regexp",
-			filter:      fmt.Sprintf("ID:%s", reg),
+			filter:      fmt.Sprintf("ip:%s", reg),
 			expectError: false,
 			expectedFilter: &Filter{
-				fieldName:       "id",
-				structFieldName: "Id",
-				pattern:         reg,
+				matchableFields: []string{
+					"PrivateIpv4",
+					"PrivateIpv6",
+					"PublicIpv4",
+					"PublicIpv6",
+				},
+				pattern: reg,
 			},
 		},
 	}

--- a/pkg/libhssh/filter_test.go
+++ b/pkg/libhssh/filter_test.go
@@ -42,7 +42,7 @@ func (s *FilterTestSuite) TestNewFilterFromString() {
 			expectedFilter: nil,
 		},
 		{
-			desc:           "Matchable field name && valid value regexp",
+			desc:           "Matchable field name && invalid value regexp",
 			filter:         "id:[syntax error)",
 			expectError:    true,
 			expectedFilter: nil,

--- a/pkg/libhssh/filter_test.go
+++ b/pkg/libhssh/filter_test.go
@@ -1,0 +1,120 @@
+package libhssh
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	cr "github.com/squarescale/cloudresolver"
+	"github.com/stretchr/testify/suite"
+)
+
+type FilterTestSuite struct {
+	suite.Suite
+}
+
+func (s *FilterTestSuite) SetupSuite() {
+}
+
+func (s *FilterTestSuite) SetupTest() {
+}
+
+func (s *FilterTestSuite) TestNewFilterFromString() {
+	reg, err := regexp.Compile("foo")
+	s.Nil(err)
+
+	testCases := []struct {
+		desc           string
+		filter         string
+		expectError    bool
+		expectedFilter *Filter
+	}{
+		{
+			desc:           "Missing ':'",
+			filter:         "x",
+			expectError:    true,
+			expectedFilter: nil,
+		},
+		{
+			desc:           "Too much ':'",
+			filter:         "x:y:z",
+			expectError:    true,
+			expectedFilter: nil,
+		},
+		{
+			desc:           "Invalid field name && valid regexp",
+			filter:         "xxx:valid",
+			expectError:    true,
+			expectedFilter: nil,
+		},
+		{
+			desc:           "Valid field name && invalid regexp",
+			filter:         "id:[syntax error)",
+			expectError:    true,
+			expectedFilter: nil,
+		},
+		{
+			desc:        "Valid field name && valid regexp",
+			filter:      fmt.Sprintf("ID:%s", reg),
+			expectError: false,
+			expectedFilter: &Filter{
+				fieldName:       "id",
+				structFieldName: "Id",
+				pattern:         reg,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		f, err := NewFilterFromString(
+			tc.filter,
+		)
+
+		if tc.expectError {
+			s.NotNil(err, tc.desc)
+			s.Nil(f, tc.desc)
+			continue
+		}
+
+		s.Nil(err, tc.desc)
+		s.Equal(tc.expectedFilter, f, tc.desc)
+	}
+}
+
+func (s *FilterTestSuite) TestHostMatch() {
+	testCases := []struct {
+		desc    string
+		filter  string
+		host    *cr.Host
+		matches bool
+	}{
+		{
+			desc:    "matches",
+			filter:  "id:aaa",
+			host:    &cr.Host{Id: "aaa"},
+			matches: true,
+		},
+		{
+			desc:    "does not match",
+			filter:  "zone:euwest",
+			host:    &cr.Host{Zone: "x"},
+			matches: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		f, err := NewFilterFromString(tc.filter)
+		s.Nil(err)
+		s.NotNil(f)
+
+		s.Equal(
+			tc.matches,
+			f.HostMatch(tc.host),
+			tc.desc,
+		)
+	}
+}
+
+func TestFilterTestSuite(t *testing.T) {
+	suite.Run(t, new(FilterTestSuite))
+}


### PR DESCRIPTION
This commit changes the way hosts are matched.

Before the filter syntax was fieldnameregex:fieldvalueregex

This commit changes this to lowercasefieldname:fieldvaludregex

Field names are lowered cloudresolver's Host attributes [1]

- id
- instancename
- private
- privateipv4
- privateipv6
- privatename
- provider
- public
- publicipv4
- publicipv6
- publicname
- region
- zone

https://github.com/squarescale/cloudresolver/blob/master/cloudresolver.go#L3

So right now we can select a specific field and apply a regex on it.