### PR TITLE
Use new version of cloudresolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,27 @@ ssh-add your-private-key
 hssh can easily be rebuilt using Golang installed version (for instance using gvm https://github.com/moovweb/gvm):
 
 ```
-gvm install go1.12.6 -b -B && \
+gvm install $(gvm listall | grep go1.12 | tail -1) -b -B && \
+gvm use $(gvm listall | grep go1.12 | tail -1) && \
 git clone https://github.com/squarescale/hssh && \
 cd hssh && \
 go build .
 ```
 
 The new hssh binary is located in the locally cloned git repository.
+
+### Making changes in modules used by hssh
+
+You can get versions of Go modules using the following command:
+
+```go list -m -versions github.com/squarescale/cloudresolver```
+
+If you create a test branch for a module, you can retrieve the corresponding tag to insert in go.mod
+by using the following command:
+
+```go list -m  github.com/squarescale/cloudresolver@<branch-name>```
+
+You then need to update go.mod file accordingly before rebuilding.
 
 ### Configuration file & usage
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/spf13/viper v1.3.1
-	github.com/squarescale/cloudresolver v0.0.0-20190308221611-b60c2a377607
+	github.com/squarescale/cloudresolver v0.0.0-20191108110146-72fc6953c899
 	github.com/squarescale/sshcommand v0.0.0-20190311110043-d5b1f8b62c87
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/squarescale/cloudresolver v0.0.0-20190213222711-726cca2c26cc/go.mod h1:HDQQ5DqN0NstyoY+b870lVfSaLW5hZRg0udFYDpJ+gw=
 github.com/squarescale/cloudresolver v0.0.0-20190308221611-b60c2a377607 h1:ZQr5a6hrqzS6UBhM2FU3lexc7Mf5T594tCY6YCb6UO4=
 github.com/squarescale/cloudresolver v0.0.0-20190308221611-b60c2a377607/go.mod h1:OlBp0ZRBe4JBPHIW8cmfXBqAkWuiAS3u2KefzYG91II=
+github.com/squarescale/cloudresolver v0.0.0-20191108110146-72fc6953c899 h1:r32hqhgILmB8f3P3UVPWgvr26UEsRdrE4fr3kHgvBLI=
+github.com/squarescale/cloudresolver v0.0.0-20191108110146-72fc6953c899/go.mod h1:OlBp0ZRBe4JBPHIW8cmfXBqAkWuiAS3u2KefzYG91II=
 github.com/squarescale/sshcommand v0.0.0-20190311110043-d5b1f8b62c87 h1:Of/Po1QUMenVZ7QjhetJLQ5I911d7GMNJNk8+jRxieE=
 github.com/squarescale/sshcommand v0.0.0-20190311110043-d5b1f8b62c87/go.mod h1:HZnRpCcUfAx3t9RaK/Gh5NS2jTGXYXcE+prfiG/hlt8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Now allowing users to also use IPv4 private addresses
and not only instances names or instance IDs.